### PR TITLE
Fix bug when manifest is merged.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,13 +7,13 @@ repositories {
 }
 
 android {
-    compileSdkVersion 22
-    buildToolsVersion "22.0.1"
+    compileSdkVersion Integer.parseInt(project.ANDROID_BUILD_SDK_VERSION)
+    buildToolsVersion project.ANDROID_BUILD_TOOLS_VERSION
 
     defaultConfig {
         applicationId "io.palaima.smoothbluetooth.app"
         minSdkVersion 15
-        targetSdkVersion 22
+        targetSdkVersion Integer.parseInt(project.ANDROID_BUILD_TARGET_SDK_VERSION)
         versionCode 1
         versionName "1.0"
     }
@@ -26,10 +26,8 @@ android {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:22.1.1'
-    compile 'com.android.support:recyclerview-v7:22.0.0'
-    compile 'com.afollestad:material-dialogs:0.6.2.1'
-    //compile project (':library')
-    compile 'io.palaima:smoothbluetooth:0.1.0'
+    compile 'com.android.support:appcompat-v7:23.1.1'
+    compile 'com.android.support:recyclerview-v7:23.1.1'
+    compile project(':library')
+    //compile 'io.palaima:smoothbluetooth:0.1.0'
 }

--- a/app/src/main/java/io/palaima/smoothbluetooth/app/MainActivity.java
+++ b/app/src/main/java/io/palaima/smoothbluetooth/app/MainActivity.java
@@ -1,17 +1,15 @@
 package io.palaima.smoothbluetooth.app;
 
-import com.afollestad.materialdialogs.MaterialDialog;
-import com.palaima.bluetooth.app.R;
-
 import android.bluetooth.BluetoothAdapter;
+import android.content.DialogInterface;
 import android.content.Intent;
 import android.os.Bundle;
+import android.support.v7.app.AlertDialog;
 import android.support.v7.app.AppCompatActivity;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.WindowManager;
-import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
 import android.widget.Button;
 import android.widget.CheckBox;
@@ -21,11 +19,13 @@ import android.widget.ListView;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import com.palaima.bluetooth.app.R;
+
 import java.util.ArrayList;
 import java.util.List;
 
-import io.palaima.smoothbluetooth.SmoothBluetooth;
 import io.palaima.smoothbluetooth.Device;
+import io.palaima.smoothbluetooth.SmoothBluetooth;
 
 
 public class MainActivity extends AppCompatActivity {
@@ -68,7 +68,7 @@ public class MainActivity extends AppCompatActivity {
         mSmoothBluetooth.setListener(mListener);
 
         ListView responseListView = (ListView) findViewById(R.id.responses);
-        mResponsesAdapter = new ArrayAdapter<>( this, android.R.layout.simple_list_item_1, mResponseBuffer);
+        mResponsesAdapter = new ArrayAdapter<>(this, android.R.layout.simple_list_item_1, mResponseBuffer);
         responseListView.setAdapter(mResponsesAdapter);
 
         mCRLFBox = (CheckBox) findViewById(R.id.carrage);
@@ -147,8 +147,8 @@ public class MainActivity extends AppCompatActivity {
     @Override
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
         super.onActivityResult(requestCode, resultCode, data);
-        if(requestCode == ENABLE_BT__REQUEST) {
-            if(resultCode == RESULT_OK) {
+        if (requestCode == ENABLE_BT__REQUEST) {
+            if (resultCode == RESULT_OK) {
                 mSmoothBluetooth.tryConnection();
             }
         }
@@ -216,37 +216,29 @@ public class MainActivity extends AppCompatActivity {
 
         @Override
         public void onDevicesFound(final List<Device> deviceList,
-                final SmoothBluetooth.ConnectionCallback connectionCallback) {
+                                   final SmoothBluetooth.ConnectionCallback connectionCallback) {
 
-            final MaterialDialog dialog = new MaterialDialog.Builder(MainActivity.this)
-                    .title("Devices")
-                    .adapter(new DevicesAdapter(MainActivity.this, deviceList))
-                    .build();
-
-            ListView listView = dialog.getListView();
-            if (listView != null) {
-                listView.setOnItemClickListener(new AdapterView.OnItemClickListener() {
-                    @Override
-                    public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
-                        connectionCallback.connectTo(deviceList.get(position));
-                        dialog.dismiss();
-                    }
-
-                });
-            }
-
-            dialog.show();
-
+            new AlertDialog.Builder(MainActivity.this)
+                    .setTitle("Device")
+                    .setAdapter(new DevicesAdapter(MainActivity.this, deviceList),
+                            new DialogInterface.OnClickListener() {
+                                @Override
+                                public void onClick(DialogInterface dialog, int which) {
+                                    connectionCallback.connectTo(deviceList.get(which));
+                                }
+                            })
+                    .create()
+                    .show();
         }
 
         @Override
         public void onDataReceived(int data) {
             mBuffer.add(data);
             if (data == 62 && !mBuffer.isEmpty()) {
-            //if (data == 0x0D && !mBuffer.isEmpty() && mBuffer.get(mBuffer.size()-2) == 0xA0) {
+                //if (data == 0x0D && !mBuffer.isEmpty() && mBuffer.get(mBuffer.size()-2) == 0xA0) {
                 StringBuilder sb = new StringBuilder();
                 for (int integer : mBuffer) {
-                    sb.append((char)integer);
+                    sb.append((char) integer);
                 }
                 mBuffer.clear();
                 mResponseBuffer.add(0, sb.toString());

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.2.3'
+        classpath 'com.android.tools.build:gradle:1.5.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,6 +21,10 @@ VERSION_NAME=0.2.0-SNAPSHOT
 VERSION_CODE=2
 GROUP=io.palaima
 
+ANDROID_BUILD_TARGET_SDK_VERSION=23
+ANDROID_BUILD_SDK_VERSION=23
+ANDROID_BUILD_TOOLS_VERSION=23.0.2
+
 POM_DESCRIPTION= An Android library made smooth for your bluetooth communication.
 POM_URL=https://github.com/palaima/AndroidSmoothBluetooth
 POM_SCM_URL=https://github.com/palaima/AndroidSmoothBluetooth

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 22
-    buildToolsVersion "22.0.1"
+    compileSdkVersion Integer.parseInt(project.ANDROID_BUILD_SDK_VERSION)
+    buildToolsVersion project.ANDROID_BUILD_TOOLS_VERSION
 
     defaultConfig {
         minSdkVersion 10
-        targetSdkVersion 22
+        targetSdkVersion Integer.parseInt(project.ANDROID_BUILD_TARGET_SDK_VERSION)
         versionCode 1
         versionName "0.1.0"
     }
@@ -19,8 +19,6 @@ android {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:22.1.1'
 }
 
 apply from: 'https://raw.github.com/chrisbanes/gradle-mvn-push/master/gradle-mvn-push.gradle'

--- a/library/src/main/AndroidManifest.xml
+++ b/library/src/main/AndroidManifest.xml
@@ -1,10 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           package="com.palaima.bluetoothmanager">
 
-    <application android:allowBackup="true"
-                 android:label="@string/app_name"
-        >
-
-    </application>
-
+    <uses-permission android:name="android.permission.BLUETOOTH_ADMIN"/>
+    <uses-permission android:name="android.permission.BLUETOOTH"/>
 </manifest>

--- a/library/src/main/res/values/strings.xml
+++ b/library/src/main/res/values/strings.xml
@@ -1,3 +1,0 @@
-<resources>
-    <string name="app_name">Smooth Bluetooth</string>
-</resources>


### PR DESCRIPTION
Update build tools.

Remove android:allowBackup="true" from manifest to fix this issue:

Error:Execution failed for task ':app:processDebugManifest'.
Manifest merger failed : Attribute application@allowBackup value=(false) from AndroidManifest.xml:9:9-36
is also present at [io.palaima:smoothbluetooth:0.1.0] AndroidManifest.xml:12:9-35 value=(true).
Suggestion: add 'tools:replace="android:allowBackup"' to <application> element at AndroidManifest.xml:8:5-40:19 to override.
